### PR TITLE
[WIP] Adopting Redux Start Kit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "vsls-communities",
-	"version": "0.0.5",
+	"version": "0.0.7",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -1086,6 +1086,11 @@
 				"randomfill": "^1.0.3"
 			}
 		},
+		"curriable": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/curriable/-/curriable-1.3.0.tgz",
+			"integrity": "sha512-7kfjDPRSF+pguU0TlfSFBMCd8XlmF29ZAiXcq/zaN4LhZvWdvV0Y72AvaWFqInXZG9Yg1kA1UMkpE9lFBKMpQA=="
+		},
 		"cyclist": {
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
@@ -1545,6 +1550,11 @@
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
 			"integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
 			"dev": true
+		},
+		"fast-equals": {
+			"version": "1.6.3",
+			"resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-1.6.3.tgz",
+			"integrity": "sha512-4WKW0AL5+WEqO0zWavAfYGY1qwLsBgE//DN4TTcVEN2UlINgkv9b3vm2iHicoenWKSX9mKWmGOsU/iI5IST7pQ=="
 		},
 		"fast-json-stable-stringify": {
 			"version": "2.0.0",
@@ -2484,6 +2494,14 @@
 				"debug": "^3.1.0"
 			}
 		},
+		"identitate": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/identitate/-/identitate-1.0.1.tgz",
+			"integrity": "sha512-xnDJ0JYhiZjBDuJRKbHoVzj5yP9FhATxLyUYswQyPdnJrwzGVBqS6DOmvKJi1lk7P+4dkL+hhUhuOZIcOUtG5A==",
+			"requires": {
+				"pathington": "^1.0.1"
+			}
+		},
 		"ieee754": {
 			"version": "1.1.13",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
@@ -2495,6 +2513,11 @@
 			"resolved": "https://registry.npmjs.org/iferr/-/iferr-0.1.5.tgz",
 			"integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE=",
 			"dev": true
+		},
+		"immer": {
+			"version": "2.1.5",
+			"resolved": "https://registry.npmjs.org/immer/-/immer-2.1.5.tgz",
+			"integrity": "sha512-xyjQyTBYIeiz6jd02Hg12jV+9QISwF1crLcwTlzHpWH4e0ryNWj1kacpTwimK3bJV5NKKXw458G2vpqoB/inFA=="
 		},
 		"import-local": {
 			"version": "2.0.0",
@@ -2545,6 +2568,14 @@
 			"resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
 			"integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
 			"dev": true
+		},
+		"invariant": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+			"requires": {
+				"loose-envify": "^1.0.0"
+			}
 		},
 		"invert-kv": {
 			"version": "2.0.0",
@@ -2791,6 +2822,11 @@
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
 			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
 			"dev": true
+		},
+		"json-stringify-safe": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
 		},
 		"json5": {
 			"version": "1.0.1",
@@ -3478,6 +3514,11 @@
 			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
 			"dev": true
 		},
+		"pathington": {
+			"version": "1.1.7",
+			"resolved": "https://registry.npmjs.org/pathington/-/pathington-1.1.7.tgz",
+			"integrity": "sha512-JxzhUzagDfNIOm4qqwQqP3rWeo7rNNOfIahy4n+3GTEdwXLqw5cJHUR0soSopQtNEv763lzxb6eA2xBllpR8zw=="
+		},
 		"pbkdf2": {
 			"version": "3.0.17",
 			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
@@ -3666,12 +3707,39 @@
 				"symbol-observable": "^1.2.0"
 			}
 		},
+		"redux-devtools-extension": {
+			"version": "2.13.8",
+			"resolved": "https://registry.npmjs.org/redux-devtools-extension/-/redux-devtools-extension-2.13.8.tgz",
+			"integrity": "sha512-8qlpooP2QqPtZHQZRhx3x3OP5skEV1py/zUdMY28WNAocbafxdG2tRD1MWE7sp8obGMNYuLWanhhQ7EQvT1FBg=="
+		},
+		"redux-immutable-state-invariant": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/redux-immutable-state-invariant/-/redux-immutable-state-invariant-2.1.0.tgz",
+			"integrity": "sha512-3czbDKs35FwiBRsx/3KabUk5zSOoTXC+cgVofGkpBNv3jQcqIe5JrHcF5AmVt7B/4hyJ8MijBIpCJ8cife6yJg==",
+			"requires": {
+				"invariant": "^2.1.0",
+				"json-stringify-safe": "^5.0.1"
+			}
+		},
 		"redux-saga": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/redux-saga/-/redux-saga-1.0.5.tgz",
 			"integrity": "sha512-ytGFtaHyz6NQMQp7/LpQ/6CtOkbPRCcAeljUpc4c95hRm5U6dFvrRiZHeBPuQZ56L3oXfTX3hiYh8/3ZudsiNg==",
 			"requires": {
 				"@redux-saga/core": "^1.0.3"
+			}
+		},
+		"redux-starter-kit": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/redux-starter-kit/-/redux-starter-kit-0.6.3.tgz",
+			"integrity": "sha512-A+7UjgmFrWdKksHl8xTGxDw6Bv8QJ+wrTubBscFNs5gIezGHOdwjqTTSVX4xMgQkgPtVfSPj/Bo+5o6f71/eTA==",
+			"requires": {
+				"immer": "^2.1.5",
+				"redux": "^4.0.0",
+				"redux-devtools-extension": "^2.13.8",
+				"redux-immutable-state-invariant": "^2.1.0",
+				"redux-thunk": "^2.2.0",
+				"selectorator": "^4.0.3"
 			}
 		},
 		"redux-thunk": {
@@ -3723,6 +3791,11 @@
 			"resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
 			"integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
 			"dev": true
+		},
+		"reselect": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/reselect/-/reselect-4.0.0.tgz",
+			"integrity": "sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA=="
 		},
 		"resolve": {
 			"version": "1.11.1",
@@ -3835,6 +3908,17 @@
 				"ajv": "^6.1.0",
 				"ajv-errors": "^1.0.0",
 				"ajv-keywords": "^3.1.0"
+			}
+		},
+		"selectorator": {
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/selectorator/-/selectorator-4.0.3.tgz",
+			"integrity": "sha512-A8+paRhzTab4Qm/38RAVnCgEZFbpn5xIWLyTCDqvyU3Obhmo94RS6UK1H00bVH7+U609sOhqbFJha09POsWURA==",
+			"requires": {
+				"fast-equals": "^1.2.1",
+				"identitate": "^1.0.0",
+				"reselect": "^4.0.0",
+				"unchanged": "^2.0.1"
 			}
 		},
 		"semver": {
@@ -4490,6 +4574,15 @@
 			"integrity": "sha512-Zcr0lbt8z5ZdEzERHAMAniTiIKerFCMgd7yjq1fPnDJ43et/k9twIFQMUYff9k5oXcsQ0WpvFcgzK2ZKASoW6Q==",
 			"requires": {
 				"typescript-compare": "^0.0.2"
+			}
+		},
+		"unchanged": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/unchanged/-/unchanged-2.2.0.tgz",
+			"integrity": "sha512-L+MJNfyvFZkjw9WYRbmZBnYncBoASRNxE9eCm5SZWc2whdw19tPVigjJXNwu+/O+nCwp1kYYT8LX+jNuJakF9w==",
+			"requires": {
+				"curriable": "^1.3.0",
+				"pathington": "^1.1.7"
 			}
 		},
 		"union-value": {

--- a/package.json
+++ b/package.json
@@ -279,6 +279,7 @@
     "ramda": "^0.26.1",
     "redux": "^4.0.4",
     "redux-saga": "^1.0.5",
+    "redux-starter-kit": "^0.6.3",
     "redux-thunk": "^2.3.0",
     "vsls": "^0.3.1291",
     "ws": "^7.1.1"

--- a/src/sagas/communities.ts
+++ b/src/sagas/communities.ts
@@ -80,7 +80,7 @@ export function* updateCommunitySaga(
   yield call(rebuildContacts, vslsApi);
 }
 
-export function* clearMessages(chatApi: ChatApi, { community }: any) {
-  yield call(api.clearMessages, community);
-  yield call(chatApi.onMessagesCleared.bind(chatApi), community);
+export function* clearMessagesSaga(chatApi: ChatApi, { payload }: any) {
+  yield call(api.clearMessages, payload);
+  yield call(chatApi.onMessagesCleared.bind(chatApi), payload);
 }

--- a/src/sagas/index.ts
+++ b/src/sagas/index.ts
@@ -12,17 +12,17 @@ import { ISessionStateChannel } from "../channels/sessionState";
 import { ChatApi } from "../chatApi";
 import { LocalStorage } from "../storage/LocalStorage";
 import {
-  ACTION_CLEAR_MESSAGES,
   ACTION_COMMUNITY_UPDATED,
   ACTION_CREATE_SESSION,
   ACTION_JOIN_COMMUNITY,
   ACTION_LEAVE_COMMUNITY,
   ACTION_LOAD_COMMUNITIES,
+  clearMessages,
   loadCommunities,
   userAuthenticationChanged
 } from "../store/actions";
 import {
-  clearMessages,
+  clearMessagesSaga,
   joinCommunity,
   leaveCommunity,
   loadCommunitiesSaga,
@@ -50,7 +50,7 @@ function* childSagas(
       ACTION_COMMUNITY_UPDATED,
       updateCommunitySaga.bind(null, vslsApi)
     ),
-    takeEvery(ACTION_CLEAR_MESSAGES, clearMessages.bind(null, chatApi)),
+    takeEvery(clearMessages, clearMessagesSaga.bind(null, chatApi)),
 
     takeEvery(ACTION_CREATE_SESSION, createSession.bind(null, vslsApi)),
     takeEvery(sessionStateChannel, endActiveSession),

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -1,3 +1,4 @@
+import { createAction } from "redux-starter-kit";
 import { Access } from "vsls";
 import {
   IActiveSession,
@@ -21,7 +22,6 @@ export const ACTION_ACTIVE_SESSION_ENDED = "ACTIVE_SESSION_ENDED";
 export const ACTION_COMMUNITY_NODE_EXPANDED = "COMMUNITY_NODE_EXPANDED";
 export const ACTION_USER_AUTHENTICATION_CHANGED = "USER_AUTHENTICATION_CHANGED";
 export const ACTION_COMMUNITY_UPDATED = "COMMUNITY_UPDATED";
-export const ACTION_CLEAR_MESSAGES = "CLEAR_MESSAGES";
 
 function action(type: string, payload = {}) {
   return { type, ...payload };
@@ -82,5 +82,4 @@ export const updateCommunity = (
   sessions: ISession[]
 ) => action(ACTION_COMMUNITY_UPDATED, { name, members, sessions });
 
-export const clearMessages = (community: string) =>
-  action(ACTION_CLEAR_MESSAGES, { community });
+export const clearMessages = createAction<string>("messages/clear");


### PR DESCRIPTION
This PR introduces a dependency on the `redux-starter-kit`, which includes a handful of helper APIs to reducer boilerplate. To begin with, I'm going to refactor all of our actions and action creators to use the `createAction` method, which allows us to have a single object that represents both the action name and creator.

Right now, this PR only refactors a single action, in order to illustrate the change. Assuming folks are cool with this change, I'll update the rest, which should dramatically simplify `actions.ts`.

In addition to this change, `redux-starter-kit` also provides helpers for simplifying your reducers, which I'll do in a follow-up PR.