### PR TITLE
[auth]: pass LS auth strategies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "extensionDependencies": [
     "MS-vsliveshare.vsliveshare-pack"
   ],
+  "aiKey": "AIF-d9b70cd4-b9f9-4d70-929b-a071c400b217",
   "contributes": {
     "commands": [
       {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,7 +27,9 @@ export async function activate(context: ExtensionContext) {
   const api = (await getVslsApi())!;
   const chatApi = new ChatApi(api, store);
 
-  await auth.init(context);
+  // need to cast `api` to `any` until new `vsls` npm package is published
+  const authStrategies = (api as any).authStrategies || [];
+  await auth.init(context, authStrategies);
 
   sessionStateChannel = createSessionStateChannel(api);
 


### PR DESCRIPTION
The PR:

1. Passes the LS auth strategies to complete integration with LS.
2. Adds apps insights key to package.json. This will pass all telemetry events to the VSCodeExtensionsUnclassified database with retention of 2 days.
