### PR TITLE
Add extension contribution point for auto-joining communities

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,15 +64,15 @@ At any time, you can also mute a community (or all communities) directly from th
 
    <img width="250px" src="https://user-images.githubusercontent.com/116461/63452124-65487b00-c3fa-11e9-8e3f-bc824cfe4bc3.png" />
 
-## Deep-Linking Your Community
+## Deep Linking Your Community
 
-In order to simplify the process for new members to join your community, you could provide a "deep link" to it, using one (or both) of the following techniques:
+To simplify the onboarding process for your community, you can provide a deep link to it, using one (or both) of the following techniques:
 
 1. Right-click your community in the `Communities` tree, and select `Copy Link to Community`. This will generate a URL that you can send to someone (e.g. via e-mail, Slack), and when clicked, it will automatically join them to the community. Additionally, you can publish this URL, along with the Live Share Communities badge, on a webpage, or GitHub repository (like this one!), so that visitors can easily discover your community.
 
    <img width="200px" src="https://user-images.githubusercontent.com/116461/63655942-2c364080-c743-11e9-9a5e-554bb5e631d7.png" />
 
-2. If you've built a VS Code extension (or extension pack), that represents your community (e.g. an opinionated set of extensions/tools for a classroom), then you can add an extension dependency to this extension (`lostintangent.vsls-communities`), as well as a `liveshare.communities` contribution point to your extenison's `package.json` file. When others install your extension, it will install Live Share + Communities, and then automaticatically join them to the specified communities.
+2. If you've built a VS Code extension (or extension pack), that represents your community (e.g. an opinionated set of extensions/tools for a classroom), then you can add an extension dependency to this extension (`lostintangent.vsls-communities`), as well as a `liveshare.communities` contribution point to your extenison's `package.json` file. When others install your extension, it will install Live Share + Communities, and then automatically join them to the specified communities.
 
    ```json
    "contributes": {

--- a/README.md
+++ b/README.md
@@ -64,6 +64,24 @@ At any time, you can also mute a community (or all communities) directly from th
 
    <img width="250px" src="https://user-images.githubusercontent.com/116461/63452124-65487b00-c3fa-11e9-8e3f-bc824cfe4bc3.png" />
 
+## Deep-Linking Your Community
+
+In order to simplify the process for new members to join your community, you could provide a "deep link" to it, using one (or both) of the following techniques:
+
+1. Right-click your community in the `Communities` tree, and select `Copy Link to Community`. This will generate a URL that you can send to someone (e.g. via e-mail, Slack), and when clicked, it will automatically join them to the community. Additionally, you can publish this URL, along with the Live Share Communities badge, on a webpage, or GitHub repository (like this one!), so that visitors can easily discover your community.
+
+   <img width="200px" src="https://user-images.githubusercontent.com/116461/63655942-2c364080-c743-11e9-9a5e-554bb5e631d7.png" />
+
+2. If you've built a VS Code extension (or extension pack), that represents your community (e.g. an opinionated set of extensions/tools for a classroom), then you can add an extension dependency to this extension (`lostintangent.vsls-communities`), as well as a `liveshare.communities` contribution point to your extenison's `package.json` file. When others install your extension, it will install Live Share + Communities, and then automaticatically join them to the specified communities.
+
+   ```json
+   "contributes": {
+      "liveshare.communities": ["<name>"]
+   }
+   ```
+
+   _Note: You can see an example of this in the [Live Share Counter](https://github.com/vsls-contrib/counter/blob/master/package.json#L46) sample_.
+
 ## FAQ
 
 **How do I create a community?**

--- a/package.json
+++ b/package.json
@@ -178,6 +178,16 @@
           "type": "boolean",
           "description": "Specifies whether to show community contacts in the Live Share Suggested Contacts tree."
         },
+        "liveshare.communities.extensionContributionBehavior": {
+          "default": "join",
+          "type": "string",
+          "enum": [
+            "ignore",
+            "join",
+            "prompt"
+          ],
+          "description": "Specifies how to respond when 3rd-party extensions declare they have an associated community."
+        },
         "liveshare.communities.mutedCommunities": {
           "default": [],
           "type": "array",

--- a/src/channels/extensions.ts
+++ b/src/channels/extensions.ts
@@ -9,8 +9,17 @@ export enum ExtensionEventType {
 }
 
 export interface IExtensionEvent {
+  id: string;
   type: ExtensionEventType;
   communities: string[];
+}
+
+function extensionAddedEvent(id: string, communities: string[]) {
+  return { id, type: ExtensionEventType.extensionAdded, communities };
+}
+
+function extensionRemovedEvent(id: string, communities: string[]) {
+  return { id, type: ExtensionEventType.extensionRemoved, communities };
 }
 
 const extensionMap = new Map<string, string[]>();
@@ -36,14 +45,14 @@ function processExtensions(
     ([id, _]) => !extensions.find(e => e.id === id)
   );
 
-  newExtensions.forEach(({ id, communities }) => {
+  newExtensions.forEach(({ id, communities = [] }) => {
     extensionMap.set(id, communities);
-    emit({ type: ExtensionEventType.extensionAdded, communities });
+    emit(extensionAddedEvent(id, communities));
   });
 
-  removedExtensions.forEach(([id, communities]) => {
+  removedExtensions.forEach(([id, communities = []]) => {
     extensionMap.delete(id);
-    emit({ type: ExtensionEventType.extensionRemoved, communities });
+    emit(extensionRemovedEvent(id, communities));
   });
 }
 

--- a/src/channels/extensions.ts
+++ b/src/channels/extensions.ts
@@ -1,0 +1,62 @@
+import { buffers, eventChannel } from "redux-saga";
+import { Extension, extensions } from "vscode";
+
+const CONTRIBUTION_TYPE = "liveshare.communities";
+
+export enum ExtensionEventType {
+  extensionAdded,
+  extensionRemoved
+}
+
+export interface IExtensionEvent {
+  type: ExtensionEventType;
+  communities: string[];
+}
+
+const extensionMap = new Map<string, string[]>();
+
+function processExtensions(
+  extensions: readonly Extension<any>[],
+  emit: Function
+) {
+  const extensionsWithCommunities = extensions
+    .filter(
+      ({ packageJSON: { contributes } }) =>
+        contributes && contributes[CONTRIBUTION_TYPE]
+    )
+    .map(({ id, packageJSON: { contributes } }) => ({
+      id,
+      communities: contributes[CONTRIBUTION_TYPE]
+    }));
+
+  const newExtensions = extensionsWithCommunities.filter(
+    e => !extensionMap.has(e.id)
+  );
+  const removedExtensions = Array.from(extensionMap.entries()).filter(
+    ([id, _]) => !extensions.find(e => e.id === id)
+  );
+
+  newExtensions.forEach(({ id, communities }) => {
+    extensionMap.set(id, communities);
+    emit({ type: ExtensionEventType.extensionAdded, communities });
+  });
+
+  removedExtensions.forEach(([id, communities]) => {
+    extensionMap.delete(id);
+    emit({ type: ExtensionEventType.extensionRemoved, communities });
+  });
+}
+
+export function createExtensionsChannel() {
+  return eventChannel((emit: Function) => {
+    processExtensions(extensions.all, emit);
+
+    const onDidChangehandler = extensions.onDidChange(e => {
+      processExtensions(extensions.all, emit);
+    });
+
+    return () => {
+      onDidChangehandler.dispose();
+    };
+  }, buffers.expanding());
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,9 +2,10 @@ import { commands, ConfigurationTarget, window, workspace } from "vscode";
 
 const liveShareConfig = workspace.getConfiguration("liveshare");
 
+const EXTENSION_CONTRIBUTION_BEHAVIOR = "extensionContributionBehavior";
 const FEATURE_SET_SETTING = "featureSet";
-const SUGGESTED_CONTACTS_SETTING = "showSuggestedContacts";
 const MUTED_COMMUNITIES = "mutedCommunities";
+const SUGGESTED_CONTACTS_SETTING = "showSuggestedContacts";
 const INSIDERS = "insiders";
 
 export const config = {
@@ -32,7 +33,19 @@ export const config = {
       }
     }
 
-    await commands.executeCommand('liveshare.enable.vscode-account.auth');
+    await commands.executeCommand("liveshare.enable.vscode-account.auth");
+  },
+
+  get extensionContributionBehavior() {
+    return this.getConfig().get<string>(EXTENSION_CONTRIBUTION_BEHAVIOR)!;
+  },
+
+  set extensionContributionBehavior(value: string) {
+    this.getConfig().update(
+      EXTENSION_CONTRIBUTION_BEHAVIOR,
+      value,
+      ConfigurationTarget.Global
+    );
   },
 
   get showSuggestedContacts() {

--- a/src/sagas/extensions.ts
+++ b/src/sagas/extensions.ts
@@ -1,32 +1,78 @@
-import { put, select, take } from "redux-saga/effects";
+import { call, put, select, take } from "redux-saga/effects";
+import { window } from "vscode";
 import {
   createExtensionsChannel,
   ExtensionEventType
 } from "../channels/extensions";
+import { config } from "../config";
 import { joinCommunity, leaveCommunity } from "../store/actions";
 import { ICommunity } from "../store/model";
+
+enum ContributionBehavior {
+  ignore = "ignore",
+  join = "join",
+  prompt = "prompt"
+}
+
+enum PromptResponse {
+  dontAskAgain = "Don't Ask Again",
+  join = "Join",
+  leave = "Leave"
+}
 
 export function* extensionsSaga() {
   const extensionsChannel = createExtensionsChannel();
 
   while (true) {
-    const { type, communities } = yield take(extensionsChannel);
+    const { id, type, communities } = yield take(extensionsChannel);
 
+    const isAddedEvent = type === ExtensionEventType.extensionAdded;
     const existingCommunities: ICommunity[] = yield select(
       store => store.communities
     );
 
-    if (type === ExtensionEventType.extensionAdded) {
-      for (let community of communities) {
-        if (!existingCommunities.find(c => c.name === community)) {
-          yield put(joinCommunity(community));
+    for (let community of communities) {
+      const communityExists = existingCommunities.find(
+        c => c.name === community
+      );
+
+      if (isAddedEvent && !communityExists) {
+        const contributionBehavior = config.extensionContributionBehavior;
+        if (contributionBehavior === ContributionBehavior.ignore) {
+          continue;
+        } else if (contributionBehavior === ContributionBehavior.prompt) {
+          const response = yield call(
+            // @ts-ignore
+            window.showInformationMessage,
+            `The "${id}" extension recommends you join the "${community}" Live Share community.`,
+            PromptResponse.dontAskAgain,
+            PromptResponse.join
+          );
+
+          if (!response) {
+            continue;
+          } else if (response === PromptResponse.dontAskAgain) {
+            config.extensionContributionBehavior = ContributionBehavior.ignore;
+            continue;
+          }
         }
-      }
-    } else {
-      for (let community of communities) {
-        if (existingCommunities.find(c => c.name === community)) {
-          yield put(leaveCommunity(community));
+
+        yield put(joinCommunity(community));
+
+        if (contributionBehavior === ContributionBehavior.join) {
+          const response = yield call(
+            // @ts-ignore
+            window.showInformationMessage,
+            `You've joined the "${community}" Live Share community based on the recommendation from "${id}".`,
+            PromptResponse.leave
+          );
+
+          if (response === PromptResponse.leave) {
+            yield put(leaveCommunity(community));
+          }
         }
+      } else if (!isAddedEvent && communityExists) {
+        yield put(leaveCommunity(community));
       }
     }
   }

--- a/src/sagas/extensions.ts
+++ b/src/sagas/extensions.ts
@@ -1,0 +1,33 @@
+import { put, select, take } from "redux-saga/effects";
+import {
+  createExtensionsChannel,
+  ExtensionEventType
+} from "../channels/extensions";
+import { joinCommunity, leaveCommunity } from "../store/actions";
+import { ICommunity } from "../store/model";
+
+export function* extensionsSaga() {
+  const extensionsChannel = createExtensionsChannel();
+
+  while (true) {
+    const { type, communities } = yield take(extensionsChannel);
+
+    const existingCommunities: ICommunity[] = yield select(
+      store => store.communities
+    );
+
+    if (type === ExtensionEventType.extensionAdded) {
+      for (let community of communities) {
+        if (!existingCommunities.find(c => c.name === community)) {
+          yield put(joinCommunity(community));
+        }
+      }
+    } else {
+      for (let community of communities) {
+        if (existingCommunities.find(c => c.name === community)) {
+          yield put(leaveCommunity(community));
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR introduces an extension point for VS Code extensions to declare they have an associated Live Share Community (“liveshare.communities”). This way, if a developer installs their extension, it will automatically join the community without needing to do anything further. Additionally, if the user disables/enables/uninstalls the extension, the associated community will be joined/left as appropriate. You can see a usage example in the [counter sample](https://github.com/vsls-contrib/counter/blob/master/package.json#L46).

The usecase I have in mind for this, is making it easy for schools/etc. that have extension packs, to associate a Live Share community along with their pack (e.g. [LBCC CS Pack](https://marketplace.visualstudio.com/items?itemName=joeparis.lbcc-cs-pack)). That way students/members can simply install a single extension/pack, and join the community without any effort. This, along with our existing deep link URL, provide rich mechanisms to simplify the community onboarding process.

The following GIF shows the experience, using the Live Share Counter sample, which I updated to include an associated community called “counter”:

![Join](https://user-images.githubusercontent.com/116461/63656157-9354f480-c745-11e9-88fb-39f8c6f1573c.gif)
